### PR TITLE
Allow user to specify output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Then add **hubot-uber** to your `external-scripts.json`:
 
 You will need to [register an app with Uber](https://developer.uber.com/apps/) and expose your [server token](https://developer.uber.com/v1/auth/#reference) as an environment variable named `HUBOT_UBER_TOKEN`.
 
+You can optionally set a `HUBOT_UBER_OUTPUT_FORMAT`. Accepted values are `table` (ASCII table), `slack` (ASCII table preceded by code block notation) and `none`. Defaults to none.
+
 ### Heroku
 
 ```

--- a/src/uber.coffee
+++ b/src/uber.coffee
@@ -76,7 +76,7 @@ module.exports = (robot) ->
   # Format for fixed width table
   sendTableOutput = (headers, rows, msg) ->
     table = new Table
-      headers: headers
+      head: headers
     for i, row of rows
       table.push row
 
@@ -86,7 +86,7 @@ module.exports = (robot) ->
   # Format for Slack
   sendSlackOutput = (headers, rows, msg) ->
     table = new Table
-      headers: headers
+      head: headers
     for i, row of rows
       table.push row
 


### PR DESCRIPTION
The default `cli-table` implementation does not look great when using a non-fixedwidth font (as is the case in many IRC clients and in Slack). This PR introduces a format abstraction that switches based on a `HUBOT_UBER_OUTPUT_FORMAT`. It will default to unformatted (splits the values with a `/` when listing them).

Fixes #3 